### PR TITLE
Add possibility for searching delivery notes by columns

### DIFF
--- a/src/Models/Archiv.php
+++ b/src/Models/Archiv.php
@@ -59,6 +59,40 @@ class Archiv
     }
 
     /**
+     * Returns meta data of delivery notes
+     *
+     * @param array $filter
+     * @param bool $withPosten
+     * @return array
+     */
+    public static function findDeliverynotes(array $filter = [], bool $withPosten = false): array
+    {
+        $archiv = new Archiv();
+
+        $defaultFilter = [
+            'ART' => 'LS',
+        ];
+
+        $filter = array_merge($defaultFilter, $filter);
+
+        /*
+         * Receives all matched results as array
+         */
+        $results = $archiv->aw($filter)[0];
+
+        /*
+         * Load all item if a delivery note is found the items needed
+         */
+        if($withPosten && count($results) > 0) {
+            foreach($results as $result) {
+                $result->posten = $archiv->deliverynotePosten($result->BELEG);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Returns result filtered by $arguments of "Auftragswesen" (AW)
      *
      * @param array $arguments

--- a/src/Models/Archiv.php
+++ b/src/Models/Archiv.php
@@ -2,12 +2,10 @@
 
 namespace Bios2000\Models;
 
+use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
-use Exception;
-use Illuminate\Support\Facades\Schema;
-use function foo\func;
 
 /*
  * TODO: This should be optimized.
@@ -116,7 +114,7 @@ class Archiv
     {
         $year = date('Y');
 
-        $result = new Collection();
+        $result = new Collection;
 
         while (1) {
             if ($kopf) {
@@ -128,18 +126,20 @@ class Archiv
             try {
                 DB::connection('bios2000')->table($tableName)->select('ART')->first();
             } catch (Exception $e) {
-                if ($year == date('Y')) continue;
+                if ($year == date('Y')) {
+                    continue;
+                }
                 break;
             }
 
             if ($kopf) {
                 if (DB::connection('bios2000')->table($tableName)
-                        ->where($arguments)
-                        ->orderBy('VERSION', 'desc')
-                        ->count() != 0) {
+                    ->where($arguments)
+                    ->orderBy('VERSION', 'desc')
+                    ->count() != 0) {
 
                     if ($year < date('Y')) {
-                        $dbResult = Cache::rememberForever('bios2000_archive_' . $archive . '_' . $year . '_kopf_' . implode('-', $arguments),
+                        $dbResult = Cache::rememberForever($this->buildCacheKey($arguments, $archive, $year, $kopf),
                             function () use ($tableName, $arguments) {
                                 return DB::connection('bios2000')->table($tableName)
                                     ->where($arguments)
@@ -156,13 +156,13 @@ class Archiv
 
             } else {
                 if (DB::connection('bios2000')->table($tableName)
-                        ->where('POSITIONS_NR', '!=', null)
-                        ->where($arguments)
-                        ->orderBy('VERSION', 'desc')
-                        ->count() != 0) {
+                    ->where('POSITIONS_NR', '!=', null)
+                    ->where($arguments)
+                    ->orderBy('VERSION', 'desc')
+                    ->count() != 0) {
 
                     if ($year < date('Y')) {
-                        $dbResult = Cache::rememberForever('bios2000_archive_' . $archive . '_' . $year . '_posten_' . implode('-', $arguments),
+                        $dbResult = Cache::rememberForever($this->buildCacheKey($arguments, $archive, $year, $kopf),
                             function () use ($tableName, $arguments) {
                                 return DB::connection('bios2000')->table($tableName)
                                     ->where('POSITIONS_NR', '!=', null)
@@ -188,4 +188,28 @@ class Archiv
         return $result;
     }
 
+    /**
+     * Builds a cache key based on the given arguments, archive, year, and type.
+     *
+     * @param array $arguments The array of arguments to include in the key.
+     * @param string $archive The archive identifier.
+     * @param string $year The year associated with the cache key.
+     * @param bool $kopf Determines if the key is for 'kopf' or 'posten'.
+     * @return string The generated cache key.
+     */
+    private function buildCacheKey(array $arguments, string $archive, string $year, bool $kopf): string
+    {
+        $strArguments = [];
+        $strKopf = $kopf ? 'kopf' : 'posten';
+
+        foreach ($arguments as $argument) {
+            if (is_array($argument)) {
+                $strArguments[] = implode('-', $argument);
+            } else {
+                $strArguments[] = $argument;
+            }
+        }
+
+        return 'bios2000_archive_' . $archive . '_' . $year . '_' . $strKopf . '_' . implode('-', $strArguments);
+    }
 }

--- a/src/Models/Archiv.php
+++ b/src/Models/Archiv.php
@@ -74,15 +74,20 @@ class Archiv
         $filter = array_merge($defaultFilter, $filter);
 
         /*
-         * Receives all matched results as array
+         * Receives all matched results as collection grouped by year and converted to single array
          */
-        $results = $archiv->aw($filter)[0];
+        $resultCollection = $archiv->aw($filter);
+        $results = [];
+
+        foreach ($resultCollection as $year) {
+            $results = array_merge($year, $results);
+        }
 
         /*
          * Load all item if a delivery note is found the items needed
          */
-        if($withPosten && count($results) > 0) {
-            foreach($results as $result) {
+        if ($withPosten && count($results) > 0) {
+            foreach ($results as $result) {
                 $result->posten = $archiv->deliverynotePosten($result->BELEG);
             }
         }

--- a/src/Models/Archive.php
+++ b/src/Models/Archive.php
@@ -53,6 +53,38 @@ class Archive
     }
 
     /**
+     * Returns meta data of delivery notes
+     *
+     * @param array $filter
+     * @param bool $withPosten
+     * @return array
+     */
+    public function find_deliverynotes(array $filter = [], bool $withPosten = false): array
+    {
+        $defaultFilter = [
+            'ART' => 'LS',
+        ];
+
+        $filter = array_merge($defaultFilter, $filter);
+
+        /*
+         * Receives all matched results as array
+         */
+        $results = $this->aw($filter)[0];
+
+        /*
+         * Load all item if a delivery note is found the items needed
+         */
+        if($withPosten && count($results) > 0) {
+            foreach($results as $result) {
+                $result->posten = $this->deliverynote_posten($result->BELEG);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Returns result filtered by $arguments of "Auftragswesen" (AW)
      *
      * @param array $arguments

--- a/src/Models/Archive.php
+++ b/src/Models/Archive.php
@@ -68,15 +68,20 @@ class Archive
         $filter = array_merge($defaultFilter, $filter);
 
         /*
-         * Receives all matched results as array
+         * Receives all matched results as collection grouped by year and converted to single array
          */
-        $results = $this->aw($filter)[0];
+        $resultCollection = $this->aw($filter);
+        $results = [];
+
+        foreach ($resultCollection as $year) {
+            $results = array_merge($year, $results);
+        }
 
         /*
          * Load all item if a delivery note is found the items needed
          */
-        if($withPosten && count($results) > 0) {
-            foreach($results as $result) {
+        if ($withPosten && count($results) > 0) {
+            foreach ($results as $result) {
                 $result->posten = $this->deliverynote_posten($result->BELEG);
             }
         }


### PR DESCRIPTION
Add function findDeliverynotes() in Class Bios2000\Models\Archiv that returns an array with all matched delivery notes in the BIOS2000 archive.

Example:
```
$filter = [
    'KUNU' => '10000',
    ['BELEG_DATUM', '>=', '23.01.2025'],
];

// Return delivery notes without positions
$result = Bios2000\Models\Archiv::findDeliverynotes($filter);

// Return delivery notes with positions
$result = Bios2000\Models\Archiv::findDeliverynotes($filter, true);
```
 
For backward compatibility add function find_deliverynotes() in Class Bios2000\Models\Archive.

Example:
```
// Return delivery notes without positions
$result = app()->bios2000->archive()->find_deliverynotes($filter)

// Return delivery notes with positions
$result = app()->bios2000->archive()->find_deliverynotes($filter, true)
```