### PR TITLE
Bugfix - findDeliverynotes returns multiple versions of delivery notes

### DIFF
--- a/src/Models/Archiv.php
+++ b/src/Models/Archiv.php
@@ -80,7 +80,16 @@ class Archiv
         $results = [];
 
         foreach ($resultCollection as $year) {
-            $results = array_merge($year, $results);
+            foreach ($year as $deliveryNote) {
+                if (
+                    isset($results[$deliveryNote->BELEG])
+                    && (int) $results[$deliveryNote->BELEG]->VERSION > (int) $deliveryNote->VERSION
+                ) {
+                    continue;
+                }
+
+                $results[$deliveryNote->BELEG] = $deliveryNote;
+            }
         }
 
         /*

--- a/src/Models/Archive.php
+++ b/src/Models/Archive.php
@@ -74,7 +74,16 @@ class Archive
         $results = [];
 
         foreach ($resultCollection as $year) {
-            $results = array_merge($year, $results);
+            foreach ($year as $deliveryNote) {
+                if (
+                    isset($results[$deliveryNote->BELEG])
+                    && (int) $results[$deliveryNote->BELEG]->VERSION > (int) $deliveryNote->VERSION
+                ) {
+                    continue;
+                }
+
+                $results[$deliveryNote->BELEG] = $deliveryNote;
+            }
         }
 
         /*


### PR DESCRIPTION
The function findDeliverynotes in Archiv.php and find_deliverynotes ind Archive.php returns all version of delivery notes. This should only returns the latest version of a delivery note.